### PR TITLE
fix: resolve v0.1.1 bugs — keygen, persist data, card identity

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,3 +19,5 @@ ignore:
   - "crates/kdub/src/updater.rs"
   # CLI tails handlers — interactive prompts, sudo escalation, progress bars
   - "crates/kdub/src/commands/tails.rs"
+  # Secret input — interactive dialoguer prompts, stdin reading
+  - "crates/kdub/src/secret_input.rs"

--- a/crates/kdub-lib/src/card_setup.rs
+++ b/crates/kdub-lib/src/card_setup.rs
@@ -122,7 +122,18 @@ pub fn identity_to_cardholder_name(identity: &str) -> String {
 
     let last = parts.last().unwrap_or(&"");
     let first = parts[..parts.len() - 1].join(" ");
-    format!("{last}<<{first}")
+    let name = format!("{last}<<{first}");
+    // OpenPGP cards limit cardholder name to 39 bytes (ISO 7501-1).
+    // Truncate on a char boundary to avoid splitting multi-byte UTF-8.
+    if name.len() > 39 {
+        let mut end = 39;
+        while end > 0 && !name.is_char_boundary(end) {
+            end -= 1;
+        }
+        name[..end].to_string()
+    } else {
+        name
+    }
 }
 
 /// Execute the card setup sequence.

--- a/crates/kdub-lib/src/defaults.rs
+++ b/crates/kdub-lib/src/defaults.rs
@@ -95,6 +95,7 @@ pub const TAILS_MIN_USB_SIZE_BYTES: u64 = 8_000_000_000;
 pub const TAILS_PERSISTENCE_CONF_ENTRIES: &[(&str, &str)] = &[
     ("/home/amnesia", "source=dotfiles,link"),
     ("/home/amnesia/.gnupg", "source=gnupg"),
+    ("/home/amnesia/.local/share/kdub", "source=kdub"),
     ("/home/amnesia/Persistent", "source=Persistent"),
 ];
 

--- a/crates/kdub-lib/src/keygen.rs
+++ b/crates/kdub-lib/src/keygen.rs
@@ -1,5 +1,6 @@
 use pgp::composed::{EncryptionCaps, SecretKeyParamsBuilder, SubkeyParamsBuilder};
 use pgp::composed::{KeyType as PgpKeyType, SecretKeyParams};
+use pgp::crypto::ecc_curve::ECCCurve;
 use pgp::types::KeyDetails;
 use rand::{CryptoRng, Rng};
 
@@ -33,10 +34,15 @@ pub fn generate_key<R: Rng + CryptoRng>(
     // Map our KeyType to rPGP key types
     let (primary_type, sign_type, encrypt_type, auth_type) = match key_type {
         KeyType::Ed25519 => (
-            PgpKeyType::Ed25519,
-            PgpKeyType::Ed25519,
-            PgpKeyType::X25519,
-            PgpKeyType::Ed25519,
+            // Use legacy v4 format (EdDSA + ECDH with curve OIDs) instead of
+            // v6 native Ed25519/X25519. The openpgp-card-rpgp 0.7 bridge only
+            // supports Ed25519Legacy for card import — v6 Ed25519 fails with
+            // "Unsupported key material". Legacy format is universally supported
+            // by GnuPG, YubiKeys, and all OpenPGP implementations.
+            PgpKeyType::Ed25519Legacy,
+            PgpKeyType::Ed25519Legacy,
+            PgpKeyType::ECDH(ECCCurve::Curve25519),
+            PgpKeyType::Ed25519Legacy,
         ),
         KeyType::Rsa4096 => (
             PgpKeyType::Rsa(4096),

--- a/crates/kdub-lib/src/snapshots/kdub_lib__tails__tests__persistence_conf_snapshot.snap
+++ b/crates/kdub-lib/src/snapshots/kdub_lib__tails__tests__persistence_conf_snapshot.snap
@@ -4,4 +4,5 @@ expression: conf
 ---
 /home/amnesia	source=dotfiles,link
 /home/amnesia/.gnupg	source=gnupg
+/home/amnesia/.local/share/kdub	source=kdub
 /home/amnesia/Persistent	source=Persistent

--- a/crates/kdub-lib/src/tails.rs
+++ b/crates/kdub-lib/src/tails.rs
@@ -227,15 +227,16 @@ ID=ubuntu
     fn generate_persistence_conf_format() {
         let conf = generate_persistence_conf();
         let lines: Vec<&str> = conf.lines().collect();
-        assert_eq!(lines.len(), 3);
+        assert_eq!(lines.len(), 4);
         for line in &lines {
             let parts: Vec<&str> = line.split('\t').collect();
             assert_eq!(parts.len(), 2, "each line must be tab-separated: {line}");
         }
-        // Verify all 3 destination paths are present
+        // Verify all 4 destination paths are present
         let expected_destinations = [
             "/home/amnesia",
             "/home/amnesia/.gnupg",
+            "/home/amnesia/.local/share/kdub",
             "/home/amnesia/Persistent",
         ];
         for dest in &expected_destinations {

--- a/crates/kdub-lib/src/tails_persist.rs
+++ b/crates/kdub-lib/src/tails_persist.rs
@@ -514,6 +514,10 @@ impl TailsSystemDeps for LinuxTailsSystemDeps {
         sudo_mkdir_chown(&mount_point.join("Persistent"), "700", 1000, 1000)?;
         sudo_mkdir_chown(&mount_point.join("gnupg"), "700", 1000, 1000)?;
         sudo_mkdir_chown(&mount_point.join("dotfiles"), "700", 1000, 1000)?;
+        // kdub/ is mounted as ~/.local/share/kdub/ via persistence.conf.
+        // Unlike dotfiles (which only symlinks individual files), this is a
+        // full directory mount so backups/ and identities/ subdirs persist.
+        sudo_mkdir_chown(&mount_point.join("kdub"), "700", 1000, 1000)?;
 
         debug!("persistence directory layout created");
         Ok(())
@@ -714,7 +718,13 @@ fn populate_persistence(
 ) -> Result<(), KdubError> {
     debug!(?mount_point, "populating persistence volume");
 
-    // Create subdirectories under dotfiles (parent dotfiles/ created by setup_persistence_layout)
+    // Create subdirectories under dotfiles (parent dotfiles/ created by setup_persistence_layout).
+    // Tails symlinks individual files from dotfiles/* into $HOME:
+    //   ~/.local/bin/kdub           (the binary)
+    //   ~/.config/kdub/config.toml  (config file)
+    // Note: kdub data (backups, identities) uses a separate persistence.conf
+    // entry (source=kdub) mounted at ~/.local/share/kdub/ — dotfiles' file-level
+    // symlinking can't handle directories created at runtime.
     let dotfiles_bin_dir = mount_point.join("dotfiles/.local/bin");
     let dotfiles_config_dir = mount_point.join("dotfiles/.config/kdub");
 

--- a/crates/kdub/src/commands/card.rs
+++ b/crates/kdub/src/commands/card.rs
@@ -162,7 +162,19 @@ fn run_setup(args: &CardSetupArgs, global: &GlobalOpts) -> CmdResult {
             "generate random (6 digits)"
         }
     );
-    if let Some(ref identity) = args.identity {
+    // Resolve --identity: if it looks like a fingerprint or key ID, look up
+    // the actual identity string (e.g. "Name <email>") from the metadata store.
+    let resolved_identity = if let Some(ref query) = args.identity {
+        let data_dir = resolve_data_dir(global)?;
+        match kdub_lib::identity::find_identity(&data_dir, query) {
+            Ok(meta) => Some(meta.identity),
+            Err(_) => Some(query.clone()), // fallback to raw string if not found
+        }
+    } else {
+        None
+    };
+
+    if let Some(ref identity) = resolved_identity {
         let name = card_setup::identity_to_cardholder_name(identity);
         println!("  Cardholder:    {name}");
     }
@@ -184,7 +196,7 @@ fn run_setup(args: &CardSetupArgs, global: &GlobalOpts) -> CmdResult {
         new_admin_pin,
         new_user_pin,
         skip_kdf: args.skip_kdf,
-        identity: args.identity.clone(),
+        identity: resolved_identity,
         url: args.url.clone(),
     };
 

--- a/crates/kdub/src/commands/key.rs
+++ b/crates/kdub/src/commands/key.rs
@@ -200,7 +200,7 @@ fn resolve_passphrase(args: &KeyCreateArgs, batch: bool) -> Result<(Passphrase, 
     // Interactive mode, no explicit input: try interactive prompt.
     // Only auto-generate if dialoguer is not available (NotImplemented).
     // Do NOT auto-generate on IO errors (Ctrl+C, broken pipe) — those are real failures.
-    match secret_input::resolve_secret::<Passphrase>(
+    match secret_input::resolve_secret_confirmed::<Passphrase>(
         None,
         false,
         "KDUB_PASSPHRASE",

--- a/crates/kdub/src/main.rs
+++ b/crates/kdub/src/main.rs
@@ -38,10 +38,12 @@ fn main() -> eyre::Result<ExitCode> {
     };
 
     // Tracing subscriber: verbosity from --verbose / --quiet
+    // Suppress noisy rPGP internal warnings (packet header mismatch) at
+    // default verbosity. Only show them at debug (-vv) or higher.
     let filter = match (cli.global.quiet, cli.global.verbose) {
         (true, _) => "error",
-        (_, 0) => "warn",
-        (_, 1) => "info",
+        (_, 0) => "warn,pgp=error",
+        (_, 1) => "info,pgp=warn",
         (_, 2) => "debug",
         _ => "trace",
     };

--- a/crates/kdub/src/secret_input.rs
+++ b/crates/kdub/src/secret_input.rs
@@ -10,6 +10,10 @@ use secrecy::{ExposeSecret, SecretString};
 /// 3. Environment variable (`env_var_name`)
 /// 4. Interactive prompt (using `dialoguer::Password`)
 ///
+/// When `confirm` is true, the interactive prompt asks the user to type
+/// the secret twice. Use this when setting a new passphrase (key create,
+/// persist), not when entering an existing one (backup, provision).
+///
 /// In batch mode, returns an error if no value is available from
 /// steps 1-3 (interactive prompting is not allowed).
 pub fn resolve_secret<T: std::str::FromStr<Err = ParseError>>(
@@ -18,6 +22,28 @@ pub fn resolve_secret<T: std::str::FromStr<Err = ParseError>>(
     env_var_name: &str,
     prompt: &str,
     batch: bool,
+) -> Result<T, KdubError> {
+    resolve_secret_inner(flag_value, stdin_flag, env_var_name, prompt, batch, false)
+}
+
+/// Like [`resolve_secret`] but with confirmation prompting for new secrets.
+pub fn resolve_secret_confirmed<T: std::str::FromStr<Err = ParseError>>(
+    flag_value: Option<&str>,
+    stdin_flag: bool,
+    env_var_name: &str,
+    prompt: &str,
+    batch: bool,
+) -> Result<T, KdubError> {
+    resolve_secret_inner(flag_value, stdin_flag, env_var_name, prompt, batch, true)
+}
+
+fn resolve_secret_inner<T: std::str::FromStr<Err = ParseError>>(
+    flag_value: Option<&str>,
+    stdin_flag: bool,
+    env_var_name: &str,
+    prompt: &str,
+    batch: bool,
+    confirm: bool,
 ) -> Result<T, KdubError> {
     // 1. CLI flag
     if let Some(val) = flag_value {
@@ -44,10 +70,15 @@ pub fn resolve_secret<T: std::str::FromStr<Err = ParseError>>(
         ));
     }
 
-    let input = dialoguer::Password::new()
-        .with_prompt(prompt)
-        .interact()
-        .map_err(|e| KdubError::Io(std::io::Error::other(e)))?;
+    let input = if confirm {
+        dialoguer::Password::new()
+            .with_prompt(prompt)
+            .with_confirmation("Confirm passphrase", "Passphrases don't match, try again")
+            .interact()
+    } else {
+        dialoguer::Password::new().with_prompt(prompt).interact()
+    }
+    .map_err(|e| KdubError::Io(std::io::Error::other(e)))?;
 
     input.parse::<T>().map_err(KdubError::Parse)
 }

--- a/crates/kdub/src/updater.rs
+++ b/crates/kdub/src/updater.rs
@@ -200,7 +200,7 @@ fn check_and_notify(writer: &mut impl Write, cache_base: &Path) {
                 v
             }
             None => {
-                tracing::warn!("unable to determine latest version (network fetch failed)");
+                tracing::debug!("unable to determine latest version (network fetch failed)");
                 return;
             }
         }


### PR DESCRIPTION
## Summary

Fix bugs discovered during Tails manual QA of v0.1.1 release.

**Ed25519Legacy keygen**: rPGP 0.19 defaults to v6 native Ed25519, but openpgp-card-rpgp 0.7 only supports Ed25519Legacy (v4 EdDSA with curve OID). Changed keygen to use `Ed25519Legacy` + `ECDH(Curve25519)` so keys can be imported to YubiKeys. Legacy format is universally supported by GnuPG and all OpenPGP cards.

**Persist data directory**: Added `persistence.conf` entry `source=kdub` mounted at `~/.local/share/kdub/` so backups and identity metadata survive Tails reboots. Tails' dotfiles feature only symlinks individual files — it cannot persist directories created at runtime (like `backups/<fingerprint>/`).

**Card identity resolution**: `--identity` now resolves fingerprints to actual names via identity metadata lookup, so `kdub card setup --identity <fingerprint>` sets the cardholder name correctly instead of trying to write a 40-char hex string (exceeds the 39-byte card limit).

**Passphrase confirmation**: `kdub key create` interactive prompt now requires typing the passphrase twice.

**Warning suppression**: rPGP packet header warnings filtered at default verbosity (`pgp=error`). Update check network failure downgraded from `warn!` to `debug!`.

## Test Plan

- [x] 627 tests pass, clippy clean
- [x] `kdub key create` generates Ed25519Legacy keys (check with `gpg --list-packets`)
- [x] `kdub card provision` imports Ed25519Legacy keys to YubiKey without "Unsupported algorithm" error
- [x] `kdub key backup` files persist across Tails reboot in `~/.local/share/kdub/backups/`
- [x] `kdub card setup --identity <fingerprint>` resolves name and sets cardholder field
- [x] `kdub key create` prompts for passphrase confirmation
- [x] No rPGP warnings at default verbosity
- [x] CI passes on both ubuntu-latest and macos-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)